### PR TITLE
veeam: fix crash on HTTP error

### DIFF
--- a/veeam/config.go
+++ b/veeam/config.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 	"net/url"
 	"strconv"
+	"strings"
 )
 
 // Config ... configuration for VEEAM
@@ -64,7 +65,8 @@ func (c *Config) GetResponse(request *http.Request) ([]byte, error) {
 		log.Println("success..")
 
 	} else {
-		return nil, fmt.Errorf("[Error]  Error: %s", err.Error())
+		data, _ := ioutil.ReadAll(resp.Body)
+		return nil, fmt.Errorf("[Error]  Error %d: %s", resp.StatusCode, strings.ToValidUTF8(string(data), ""))
 	}
 
 	return ioutil.ReadAll(resp.Body)


### PR DESCRIPTION
The error variable is nil in this code path:
Terraform crashes when the HTTP response is not 2XX.
We may instead print the response code along with the HTTP
body.

Signed-off-by: Fatih Acar <fatih.acar@nerim.com>