### PR TITLE
veeam: add hierarchy_name property to job resource

### DIFF
--- a/veeam/get_resources.go
+++ b/veeam/get_resources.go
@@ -40,7 +40,7 @@ func getJobID(config Config, jobName string) (string, error) {
 }
 
 //getVmObject ... fetch vm object reference to add vm in job
-func getVMObject(config Config, vmName string) (string, error) {
+func getVMObject(config Config, vmName, vmHierarchyName string) (string, error) {
 	url := "hierarchyRoots"
 	request, err := http.NewRequest("GET", url, nil)
 	if err != nil {
@@ -57,7 +57,13 @@ func getVMObject(config Config, vmName string) (string, error) {
 		log.Fatal(err)
 	}
 
-	hierarchyRootID := gjson.Get(responseToString, "Refs.0.UID")
+	var hierarchyRootID gjson.Result
+	if vmHierarchyName == "" {
+		hierarchyRootID = gjson.Get(responseToString, "Refs.0.UID")
+	} else {
+		hierarchyRootID = gjson.Get(responseToString, "Refs.#(Name="+vmHierarchyName+").UID")
+	}
+
 	log.Println(hierarchyRootID.String())
 
 	newurl := "lookup?host=" + hierarchyRootID.String() + "&name=" + vmName + "&type=Vm"

--- a/veeam/resource_veeam_job.go
+++ b/veeam/resource_veeam_job.go
@@ -33,6 +33,11 @@ func resourceVeeamJobVM() *schema.Resource {
 				Optional: true,
 				ForceNew: true,
 			},
+			"vm_hierarchy_name": &schema.Schema{
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
+			},
 		},
 	}
 }
@@ -45,6 +50,7 @@ func resourceVeeamJobVMCreate(d *schema.ResourceData, meta interface{}) error {
 	vmName := d.Get("vm_name").(string)
 	vmOrder := d.Get("vm_order").(string)
 	vmGpo := d.Get("vm_gpo").(string)
+	vmHierarchyName := d.Get("vm_hierarchy_name").(string)
 
 	//fetch job ID
 	jobID, err := getJobID(config, jobName)
@@ -53,7 +59,7 @@ func resourceVeeamJobVMCreate(d *schema.ResourceData, meta interface{}) error {
 		return fmt.Errorf("[Error]  Error: %s", err.Error())
 	}
 	//fetch vmObjectReference using vmname
-	vmObjectRef, err := getVMObject(config, vmName)
+	vmObjectRef, err := getVMObject(config, vmName, vmHierarchyName)
 	if err != nil {
 		log.Printf("[ERROR] Error in getting VM Object Reference %s", err)
 		return fmt.Errorf("[Error]  Error: %s", err.Error())


### PR DESCRIPTION
We may have multiple hierarchy roots in Veeam (multiple VMware hosts, etc).
If the VM name is not found in the first hierarchy root, Terraform will
throw an error.
Add a vm_hierarchy_name property to the veeam_job resource in order to
configure the hierarchy root to lookup when adding a VM to a job.

Signed-off-by: Fatih Acar <fatih.acar@nerim.com>