### PR TITLE
provider: add a scheme parameter

### DIFF
--- a/veeam/config.go
+++ b/veeam/config.go
@@ -16,12 +16,13 @@ type Config struct {
 	Port     int
 	Username string
 	Password string
+	Scheme   string
 }
 
 // GetResponse ... get Response according to request
 func (c *Config) GetResponse(request *http.Request) ([]byte, error) {
 
-	token, err := GetToken(c.ServerIP, c.Port, c.Username, c.Password)
+	token, err := GetToken(c.ServerIP, c.Port, c.Username, c.Password, c.Scheme)
 	if err != nil {
 		log.Println("[ERROR] Error in getting token")
 		return nil, fmt.Errorf("[Error] .\n Error: %s", err.Error())
@@ -31,7 +32,7 @@ func (c *Config) GetResponse(request *http.Request) ([]byte, error) {
 	}
 
 	var tempURL *url.URL
-	tempURL, err = url.Parse("http://" + c.ServerIP + ":" + strconv.Itoa(c.Port) + "/api/" + request.URL.String())
+	tempURL, err = url.Parse(c.Scheme + "://" + c.ServerIP + ":" + strconv.Itoa(c.Port) + "/api/" + request.URL.String())
 	if err != nil {
 		log.Println("[Error] URL is not in correct format")
 		return nil, fmt.Errorf("[Error]  Error: %s", err.Error())

--- a/veeam/provider.go
+++ b/veeam/provider.go
@@ -39,6 +39,13 @@ func Provider() terraform.ResourceProvider {
 				Description: "The user password of the VEEAM Server",
 				DefaultFunc: schema.EnvDefaultFunc("VEEAM_SERVER_PASSWORD", nil),
 			},
+
+			"scheme": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: "The scheme used to connect to the VEEAM server (either HTTP or HTTPS)",
+				DefaultFunc: schema.EnvDefaultFunc("VEEAM_SERVER_SCHEME", "http"),
+			},
 		},
 
 		ResourcesMap: map[string]*schema.Resource{
@@ -55,6 +62,7 @@ func providerConfigure(d *schema.ResourceData) (interface{}, error) {
 		Port:     d.Get("port").(int),
 		Username: d.Get("username").(string),
 		Password: d.Get("password").(string),
+		Scheme:   d.Get("scheme").(string),
 	}
 	log.Printf("[DEBUG] Connecting to veeam backup server.......")
 	return config, nil

--- a/veeam/session_manager.go
+++ b/veeam/session_manager.go
@@ -9,9 +9,9 @@ import (
 )
 
 // GetToken ... Get Token from existing store or create a new one.
-func GetToken(serverIP string, port int, username, password string) (string, error) {
+func GetToken(serverIP string, port int, username, password, scheme string) (string, error) {
 
-	token, err := getTokenFromHost(serverIP, port, username, password)
+	token, err := getTokenFromHost(serverIP, port, username, password, scheme)
 	if err != nil {
 		log.Printf("[Error] Cannot get Token : %s", err.Error())
 		return "", err
@@ -19,8 +19,8 @@ func GetToken(serverIP string, port int, username, password string) (string, err
 	return token, nil
 }
 
-func getTokenFromHost(serverIP string, port int, username, password string) (string, error) {
-	req, err := http.NewRequest("POST", "http://"+serverIP+":"+strconv.Itoa(port)+"/api/sessionMngr/?v=v1_4", nil)
+func getTokenFromHost(serverIP string, port int, username, password, scheme string) (string, error) {
+	req, err := http.NewRequest("POST", scheme+"://"+serverIP+":"+strconv.Itoa(port)+"/api/sessionMngr/?v=v1_4", nil)
 	if err != nil {
 		log.Println("[ERROR] Error while requesting sessionID ", err)
 		return "", err


### PR DESCRIPTION
HTTP is currently hardcoded in the provider.
Veeam may only allow HTTPS connections.
Add a new 'scheme' parameter to the provider configuration
in order to make the scheme configurable (either HTTP or HTTPS).
HTTP is used by default to keep compatibility.

Signed-off-by: Fatih Acar <fatih.acar@nerim.com>